### PR TITLE
V16-fix mutltiple variable definitions and buffer overwrite

### DIFF
--- a/tape.c
+++ b/tape.c
@@ -14,6 +14,7 @@ extern void Clear_atari_sector_buffer();
 
 unsigned short block;
 unsigned short baud;
+t_flags tape_flags;
 
 void set_tape_baud () {
 	//UBRR = (F_CPU/16/BAUD)-1 +U2X

--- a/tape.h
+++ b/tape.h
@@ -1,3 +1,6 @@
+#ifndef __TAPE_H__
+#define __TAPE_H__
+
 #define BLOCK_LEN 128
 
 struct tape_FUJI_hdr {
@@ -7,13 +10,16 @@ struct tape_FUJI_hdr {
 	char data[];
 };
 
-struct t_flags {
+typedef struct st_flags {
 	unsigned int offset;
 	unsigned char run : 1;
 	unsigned char FUJI : 1;
 	unsigned char turbo : 1;
-} tape_flags;
+} t_flags;
 
 unsigned int send_tape_block (unsigned int offset);
 void check_for_FUJI_file ();
 unsigned int send_FUJI_tape_block (unsigned int offset);
+extern t_flags tape_flags;
+
+#endif

--- a/tft.c
+++ b/tft.c
@@ -88,13 +88,11 @@ unsigned int action_tape_start (const struct button *b) {
 	const struct button *pb = &tft.pages[actual_page].buttons[1];
 	struct b_flags *pause = pgm_read_ptr(&pb->flags);
 
-	//clear Start button
-	flags->selected = 0;
-	//clear also the Pause Button
-	pause->selected = 0;
-
 	if(tape_flags.run || pause->selected) { //Stop
 		tape_flags.run = 0;
+		flags->selected = 0;
+		//clear also the Pause Button
+		pause->selected = 0;
 		print_str_P(35,132,2,Yellow,window_bg, PSTR("Stopped...   "));
 		draw_Buttons();
 	}
@@ -146,7 +144,6 @@ unsigned int action_cancel () {
 	debug = 0;
 	//same for tape_page
 	tape_mode = 0;
-	tape_flags.run = 0;
 	//and reset to main_page
 	actual_page = PAGE_MAIN;
 	tft.pages[actual_page].draw();
@@ -337,7 +334,7 @@ unsigned int action_change (const struct button *b) {
 }
 
 void print_pokeydiv () {
-	char buf[3];
+	char buf[8];
 	sprintf_P(buf, PSTR("$%02X"), pokeydiv);
 	print_str(150,95,2,Yellow,window_bg,buf);
 }
@@ -671,7 +668,7 @@ void file_page () {
 void config_page () {
 	const struct button *b;
 	struct b_flags *flags;
-	unsigned char i;
+	unsigned int i;
 
 	Draw_Rectangle(10,40,tft.width-11,280,1,SQUARE,window_bg,Black);
 	Draw_Rectangle(10,40,tft.width-11,280,0,SQUARE,Grey,Black);
@@ -689,16 +686,6 @@ void config_page () {
 }
 
 void tape_page () {
-	const struct button *b;
-	struct b_flags *flags;
-	unsigned char i;
-
-	for(i = 0; i < 2; i++) {	//reset Start/Pause buttons
-		b = &tft.pages[actual_page].buttons[i];
-		flags = pgm_read_ptr(&b->flags);
-		flags->selected = 0;
-	}
-
 	Draw_Rectangle(5,100,tft.width-6,245,1,SQUARE,window_bg,Black);
 	Draw_Rectangle(5,100,tft.width-6,245,0,SQUARE,Grey,Black);
 	Draw_Rectangle(6,101,tft.width-7,244,0,SQUARE,Grey,Black);


### PR DESCRIPTION
Fixed
- Buffer overwrite in TFT.c for the pokey divisor value
- Duplicate tape_flags values
- Added ifdef guard to tape.h