### PR TITLE
Fixed up compliation errors on Fedora 42

### DIFF
--- a/tape.c
+++ b/tape.c
@@ -10,7 +10,7 @@
 
 extern unsigned char atari_sector_buffer[];
 extern struct FileInfoStruct FileInfo;
-extern void Clear_atari_sector_buffer();
+extern void Clear_atari_sector_buffer(u16);
 
 unsigned short block;
 unsigned short baud;

--- a/tft.c
+++ b/tft.c
@@ -40,7 +40,7 @@ void main_page();
 void file_page();
 void config_page();
 void tape_page();
-unsigned int debug_page();
+unsigned int debug_page(const struct button *b);
 
 struct display tft;
 struct TSPoint p;
@@ -139,7 +139,7 @@ unsigned int action_tape_pause (const struct button *b) {
 	return(0);
 }
 
-unsigned int action_cancel () {
+unsigned int action_cancel (const struct button *b) {
 	//on file_page reset file index to same page
 	if (actual_page == PAGE_FILE)
 		next_file_idx -= 10;
@@ -165,7 +165,7 @@ void pretty_name(char *b) {	//insert dot in filename.ext
 	b[12] = 0;	//mark new end
 }
 
-unsigned int list_files () {
+unsigned int list_files (const struct button *b) {
 	unsigned int i;
 	unsigned int col;
 	unsigned char e;
@@ -247,29 +247,29 @@ unsigned int list_files () {
 	return(0);
 }
 
-unsigned int list_files_rev () {
+unsigned int list_files_rev (const struct button *b) {
 	if (next_file_idx >= 20) {
 		next_file_idx -= 20;
-		list_files();
+		list_files(b);
 	}
 	return(0);
 }
 
-unsigned int list_files_top () {
+unsigned int list_files_top (const struct button *b) {
 	next_file_idx = 0;
-	list_files();
+	list_files(b);
 	return(0);
 }
 
-unsigned int list_files_last () {
+unsigned int list_files_last (const struct button *b) {
 	//unsigned short i = 0;
 	//while (fatGetDirEntry(i,0)) i++;
 	next_file_idx = (nfiles-1)/10*10;
-	list_files();
+	list_files(b);
 	return(0);
 }
 
-unsigned int action_select() {
+unsigned int action_select(const struct button *b) {
 	unsigned int file;
 
 	file = p.y - 45;	// 45-280 => 0-235
@@ -303,13 +303,13 @@ unsigned int action_select() {
 		file_selected = file;
 		next_file_idx -= 10;	// the same list again
 	}
-	list_files();
+	list_files(b);
 	//read file again, that we have the long name in buffer
 	fatGetDirEntry(file,1);
 	return(0);
 }
 
-unsigned int action_ok () {
+unsigned int action_ok (const struct button *b) {
 	actual_page = PAGE_MAIN;
 	next_file_idx -= 10;
 	if(tape_mode) {
@@ -323,7 +323,7 @@ unsigned int action_ok () {
 	return(file_selected);
 }
 
-unsigned int action_cfg () {
+unsigned int action_cfg (const struct button *b) {
 	actual_page = PAGE_CONFIG;
 	tft.pages[actual_page].draw();
 	return(0);
@@ -343,7 +343,7 @@ void print_pokeydiv () {
 	print_str(150,95,2,Yellow,window_bg,buf);
 }
 
-unsigned int action_pokey () {
+unsigned int action_pokey (const struct button *b) {
 	pokeydiv++;
 	if(pokeydiv > 40)
 		pokeydiv = 0;
@@ -355,7 +355,7 @@ unsigned int action_pokey () {
 	return(0);
 }
 
-unsigned int action_save_cfg () {
+unsigned int action_save_cfg (const struct button *sb) {
 	const struct button *b;
 	struct b_flags *flags;
 	unsigned char i;
@@ -389,7 +389,7 @@ unsigned int action_save_cfg () {
 		eeprom_update_word(&MINX, 0xffff);	//force new calibration
 		tft_Setup();
 	}
-	action_cancel();
+	action_cancel(sb);
 	return(0);
 }
 
@@ -477,7 +477,7 @@ unsigned int action_cal () {
 	return(0);
 }
 
-unsigned int press () {	//for buttons with no action here
+unsigned int press (const struct button *b) {	//for buttons with no action here
 	return(0);
 }
 
@@ -666,7 +666,7 @@ void file_page () {
 	//Draw_Rectangle(12,42,tft.width-13,278,0,SQUARE,Grey,Black);
 	draw_Buttons();
 	file_selected = -1;
-	list_files();
+	list_files(NULL);
 }
 
 void config_page () {
@@ -708,7 +708,7 @@ void tape_page () {
 	draw_Buttons();
 }
 
-unsigned int debug_page () {
+unsigned int debug_page (const struct button *b) {
 
 	TFT_fill(atari_bg);
 


### PR DESCRIPTION
Fixed up many of the function handlers.  The signatures did not match on what was required. 
There should not be any functional differences with the change other than it will compile on Fedora 42